### PR TITLE
feat: records list view FR-02 #4

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,23 @@
 import { useRecords } from '@/hooks/useRecords'
 import { RecordForm } from '@/components/RecordForm'
+import { RecordList } from '@/components/RecordList'
 
 function App() {
-  const { addRecord } = useRecords()
+  const { records, addRecord } = useRecords()
+
+  function handleEdit(id: string) {
+    console.log('edit', id)
+  }
+
+  function handleDelete(id: string) {
+    console.log('delete', id)
+  }
 
   return (
     <div className="min-w-[1024px] max-w-5xl mx-auto p-8 space-y-8">
       <h1 className="text-2xl font-bold">btracker</h1>
       <RecordForm onAdd={addRecord} />
+      <RecordList records={records} onEdit={handleEdit} onDelete={handleDelete} />
     </div>
   )
 }

--- a/src/components/RecordList.tsx
+++ b/src/components/RecordList.tsx
@@ -1,0 +1,84 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { Button } from '@/components/ui/button'
+import type { BloodRecord } from '@/types/BloodRecord'
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+const EMPTY = '—'
+
+type Props = {
+  records: BloodRecord[]
+  onEdit: (id: string) => void
+  onDelete: (id: string) => void
+}
+
+export function RecordList({ records, onEdit, onDelete }: Props) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Records</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {records.length === 0 ? (
+          <p className="text-muted-foreground text-sm text-center py-8">
+            No records yet. Add your first one above.
+          </p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Date</TableHead>
+                <TableHead>Blood Pressure</TableHead>
+                <TableHead>Heart Rate</TableHead>
+                <TableHead>Glucose</TableHead>
+                <TableHead>Notes</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {records.map((record) => (
+                <TableRow key={record.id}>
+                  <TableCell className="whitespace-nowrap">{formatDate(record.date)}</TableCell>
+                  <TableCell className="whitespace-nowrap">
+                    {record.systolic}/{record.diastolic} mmHg
+                  </TableCell>
+                  <TableCell>
+                    {record.heartRate != null ? `${record.heartRate} bpm` : EMPTY}
+                  </TableCell>
+                  <TableCell>
+                    {record.glucose != null ? `${record.glucose} mg/dL` : EMPTY}
+                  </TableCell>
+                  <TableCell className="max-w-[200px] truncate">
+                    {record.notes ?? EMPTY}
+                  </TableCell>
+                  <TableCell className="text-right whitespace-nowrap">
+                    <Button variant="outline" size="sm" onClick={() => onEdit(record.id)}>
+                      Edit
+                    </Button>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      className="ml-2"
+                      onClick={() => onDelete(record.id)}
+                    >
+                      Delete
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
## Summary

Closes #4

- **`src/components/RecordList.tsx`** — ShadCN `Table` displaying all records
  - Columns: Date, Blood Pressure (sys/dia mmHg), Heart Rate, Glucose, Notes, Actions
  - Optional fields show `—` when not set
  - Notes column capped at 200px with `truncate`
  - Date formatted with `toLocaleString` (e.g. `04 Mar 2026, 14:30`)
  - Edit / Delete buttons per row — handlers stubbed with `console.log`, wired in issues #5 and #6
  - Empty state paragraph when no records exist
- **`src/App.tsx`** — `RecordList` rendered below the form, sharing `useRecords` state so new records appear immediately without reload

## Test plan

- [ ] Add a record via the form → appears at top of list instantly
- [ ] Optional fields left empty → shows `—` in those columns
- [ ] All fields filled → all columns show correct values with units
- [ ] Empty state shown when no records exist
- [ ] `npm run build` passes (✓ verified locally)
- [ ] `npm test` — 6/6 passing (✓ verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)